### PR TITLE
Allow passing deltaTime to CameraControl movements

### DIFF
--- a/src/CameraControls/CameraControls.tsx
+++ b/src/CameraControls/CameraControls.tsx
@@ -260,10 +260,10 @@ export const CameraControls: FC<
         controls: cameraRef.current,
         zoomIn: () => zoomIn(),
         zoomOut: () => zoomOut(),
-        panLeft: () => panLeft({ deltaTime: 1 }),
-        panRight: () => panRight({ deltaTime: 1 }),
-        panDown: () => panDown({ deltaTime: 1 }),
-        panUp: () => panUp({ deltaTime: 1 }),
+        panLeft: (deltaTime = 1) => panLeft({ deltaTime }),
+        panRight: (deltaTime = 1) => panRight({ deltaTime }),
+        panDown: (deltaTime = 1) => panDown({ deltaTime }),
+        panUp: (deltaTime = 1) => panUp({ deltaTime }),
         resetControls: (animated?: boolean) =>
           cameraRef.current?.reset(animated)
       }),


### PR DESCRIPTION
Looks like a bug.
When use keys(up,down,left,right) to move canvas it works fine, but when click on button in UI to move canvas (up,down,left,right) visually it doesn't show any movements, but in real it's very tiny unnoticeable movement.
This PR fixes the issue. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
