### PR TITLE
Add ability to set defaultGeomerty property for <Ring/> via Theme

### DIFF
--- a/src/symbols/Node.tsx
+++ b/src/symbols/Node.tsx
@@ -284,6 +284,7 @@ export const Node: FC<NodeProps> = ({
         opacity={isSelected ? 0.5 : 0}
         size={nodeSize}
         animated={animated}
+        defaultGeometry={theme.ring.defaultGeometry}
         color={isSelected || active ? theme.ring.activeFill : theme.ring.fill}
       />
       {menuVisible && contextMenu && (

--- a/src/symbols/Ring.tsx
+++ b/src/symbols/Ring.tsx
@@ -24,9 +24,20 @@ export interface RingProps {
    * The opacity of the ring.
    */
   opacity?: number;
+
+  /**
+   * The defaultGeometry ring size which is taken fron Theme.
+   */
+  defaultGeometry?: [number, number, number];
 }
 
-export const Ring: FC<RingProps> = ({ color, size, opacity, animated }) => {
+export const Ring: FC<RingProps> = ({
+  color,
+  size,
+  opacity,
+  animated,
+  defaultGeometry
+}) => {
   const normalizedColor = useMemo(() => new Color(color), [color]);
 
   const { ringSize, ringOpacity } = useSpring({
@@ -47,7 +58,7 @@ export const Ring: FC<RingProps> = ({ color, size, opacity, animated }) => {
   return (
     <Billboard position={[0, 0, 1]}>
       <a.mesh scale={ringSize as any}>
-        <ringGeometry attach="geometry" args={[4, 4.5, 25]} />
+        <ringGeometry attach="geometry" args={defaultGeometry} />
         <a.meshBasicMaterial
           attach="material"
           color={normalizedColor}
@@ -65,5 +76,6 @@ export const Ring: FC<RingProps> = ({ color, size, opacity, animated }) => {
 Ring.defaultProps = {
   color: '#D8E6EA',
   size: 1,
-  opacity: 0.5
+  opacity: 0.5,
+  defaultGeometry: [4, 4.5, 25]
 };

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -20,6 +20,7 @@ export interface Theme {
   ring: {
     fill: ColorRepresentation;
     activeFill: ColorRepresentation;
+    defaultGeometry: [number, number, number];
   };
   edge: {
     fill: ColorRepresentation;


### PR DESCRIPTION
Ability to manage geometry of the `<Ring/>` object. For example make it thicker or thinner. 
Well, the general idea to define `defaultGeometry` in Theme and then, apply that theme to `<GraphCanvas/>`

To make thicker:
```js
defaultGeometry: [4, 7, 25]
```
 
To make thinner
```js
defaultGeometry: [4, 2, 25]
```
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
